### PR TITLE
Decode and reduce dimensionality of bird songs

### DIFF
--- a/decoding.py
+++ b/decoding.py
@@ -266,7 +266,7 @@ if __name__ == "__main__":
                         help="Use raw spectrograms for UMAP instead of model embeddings.")
     parser.add_argument("--state_finding_algorithm_umap", type=str, default="HDBSCAN",
                         help="Algorithm for state finding in UMAP (e.g., HDBSCAN).")
-    parser.add_argument("--context_umap", type=int, default=1000,
+    parser.add_argument("--context_umap", type=int, default=500,
                         help="Context size used for UMAP generation.")
 
     # Single Mode specific arguments

--- a/src/model.py
+++ b/src/model.py
@@ -46,7 +46,7 @@ class CustomMultiHeadAttention(nn.Module):
         if self.pos_enc_type == "relative":
             seq_len = Q.size(1)
             if seq_len > self.max_len:
-                raise ValueError("Sequence length exceeds model capacity")
+                raise ValueError(f"Sequence length ({seq_len}) exceeds model capacity ({self.max_len}). Use --context_umap {self.max_len} or smaller.")
 
             # Compute relative positional encodings with skew operation
             Er = self.Er[:seq_len, :]


### PR DESCRIPTION
Align default UMAP context with model capacity and improve error message for sequence length mismatch.

The `TweetyBERT` model has a hardcoded `max_len` (often 500) for its relative positional encoding. The `decoding.py` script's default `context_umap` was 1000, leading to a `ValueError` when the model tried to process sequences longer than its capacity. This PR sets the default `context_umap` to 500 to prevent this common issue and provides a more helpful error message for future debugging.

---

[Open in Web](https://cursor.com/agents?id=bc-099fdc2e-6aab-4b01-933d-35cf0f743f4b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-099fdc2e-6aab-4b01-933d-35cf0f743f4b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)